### PR TITLE
Extend DevZone Login Token Lifetime

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,8 @@ exports.handler = async (event) => {
                   IdentityPoolId: cognitoIdentityPoolId,
                   Logins: {
                     [cognitoDeveloperProvider]: `${Username}@devzone`
-                  }
+                  },
+                  TokenDuration: 86400 // Token lifetime 24hrs
                 })
                 .promise()
                 .then(({ IdentityId, Token }) => {


### PR DESCRIPTION
* This is the first part of https://projecttools.nordicsemi.no/jira/browse/IRIS-1080 which is extending the OpenIdToken from 15 minutes (default) to 24 hours (max).  
https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetOpenIdTokenForDeveloperIdentity.html