### PR TITLE
Update lambda - Include refresh token in redirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,8 +119,7 @@ exports.handler = async (event) => {
                         .then(() => resolve({
                           statusCode: 303,
                           headers: {
-                            // eslint-disable-next-line no-template-curly-in-string
-                            'Location': redirectTo.replace('${token}', Token).replace('${refreshToken}', RefreshToken)
+                            'Location': redirectTo.replace('${token}', Token) // eslint-disable-line no-template-curly-in-string
                           }
                         }))
                     })

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ exports.handler = async (event) => {
                         .then(() => resolve({
                           statusCode: 303,
                           headers: {
-                            'Location': redirectTo.replace('${token}', Token) // eslint-disable-line no-template-curly-in-string
+                            'Location': redirectTo.replace('${token}', Token).replace('${refreshToken}', RefreshToken) // eslint-disable-line no-template-curly-in-string
                           }
                         }))
                     })

--- a/lambdas/authorize.js
+++ b/lambdas/authorize.js
@@ -119,7 +119,8 @@ exports.handler = async (event) => {
                         .then(() => resolve({
                           statusCode: 303,
                           headers: {
-                            'Location': redirectTo.replace('${token}', Token) // eslint-disable-line no-template-curly-in-string
+                            // eslint-disable-next-line no-template-curly-in-string
+                            'Location': redirectTo.replace('${token}', Token).replace('${refreshToken}', RefreshToken)
                           }
                         }))
                     })


### PR DESCRIPTION
* Issue: https://projecttools.nordicsemi.no/jira/browse/IRIS-1396, 2nd part of https://projecttools.nordicsemi.no/jira/browse/IRIS-1080

**Test** 
Sign into devzone using the local oauth client: https://devzone.nordicsemi.com/api.ashx/v2/oauth/authorize?response_type=code&client_id=08bf63d0-483a-4891-a311-9f12a80747bf&redirect_uri=https%3A%2F%2Flocal.account.nrfcloud.com%2Fweb%2F
Once signed in through DevZone, the redirect to local.account.nrfcloud.com/web includes the code token and refresh token.

